### PR TITLE
SlotService.buildListSlot, set the date and time field of slots from the db

### DIFF
--- a/src/java/fr/paris/lutece/plugins/appointment/service/SlotService.java
+++ b/src/java/fr/paris/lutece/plugins/appointment/service/SlotService.java
@@ -145,6 +145,7 @@ public final class SlotService
         // Get all the slot between these two dates
         HashMap<LocalDateTime, Slot> mapSlot = SlotService.findSlotsByIdFormAndDateRange( nIdForm, startingDateToUse.atStartOfDay( ),
                 endingDate.atTime( LocalTime.MAX ) );
+        mapSlot.values().forEach(SlotService::addDateAndTimeToSlot);
 
         // Get or build all the event for the period
         while ( !dateTemp.isAfter( endingDate ) )


### PR DESCRIPTION
@lolobuell Is this patch OK, or is it by design that some slots (the computed ones) have their date field set and some slots (the ones from the db) don't?