### PR TITLE
RENDEZVOUS-439: the calendar template id should be referenced as  template.idCalendar…

### DIFF
--- a/webapp/WEB-INF/templates/admin/plugins/appointment/templates/create_modify_calendar_template.html
+++ b/webapp/WEB-INF/templates/admin/plugins/appointment/templates/create_modify_calendar_template.html
@@ -3,7 +3,7 @@
 		<div class="box box-primary">
 			<div class="box-header with-border">
 				<h3 class="box-title">
-					<#if template.id?? && template.id &gt; 0>
+					<#if template.idCalendarTemplate?? && template.idCalendarTemplate &gt; 0>
 						#i18n{appointment.createModifyCalendarTemplate.pageTitleModify}
 					<#else>
 						#i18n{appointment.labelAddTemplate}
@@ -42,8 +42,8 @@
 					</div>
 					<div class="form-group">
 						<div class="col-xs-12 col-sm-12 col-md-offset-3 col-lg-offset-3">
-						<#if (template.id)?? && template.id &gt; 0>
-							<input type="hidden" name="id" value="${template.id}">
+						<#if (template.idCalendarTemplate)?? && template.idCalendarTemplate &gt; 0>
+							<input type="hidden" name="idCalendarTemplate" value="${template.idCalendarTemplate}">
 						</#if>
 							<button name="action" value="doCreateModifyTemplate" class="btn btn-sm btn-primary">
 								<i class="fa fa-check" aria-hidden="true"></i><span class="hidden-xs">&nbsp;#i18n{portal.util.labelOk}</span>


### PR DESCRIPTION
…Template, not as template.id in create_modify_calendar_template.html

without this change, an attempt to modify an existing calendar template (change its name) will result in creating a new template instead