### PR TITLE
Add missing javascript libraries to appointment form creation template

### DIFF
--- a/webapp/WEB-INF/templates/admin/plugins/appointment/appointmentform/create_appointmentform.html
+++ b/webapp/WEB-INF/templates/admin/plugins/appointment/appointmentform/create_appointmentform.html
@@ -1,7 +1,9 @@
 <link rel='stylesheet' href='css/plugins/appointment/bootstrap-datetimepicker.css' />
 <script src="js/jquery/jquery.min.js"></script>
+<script src="js/jquery/jquery-ui.min.js"></script>
 <script src="js/plugins/appointment/moment.min.js"></script>
 <script src="js/plugins/appointment/bootstrap-datetimepicker.min.js"></script>
+<script src="js/bootstrap-filestyle.min.js"></script>
 <@row>
 	<@tform id='formid' class='form-horizontal' method='post' action='jsp/admin/plugins/appointment/ManageAppointmentForms.jsp' params='enctype=\'multipart/form-data\''>
 		<@columns>


### PR DESCRIPTION
If you try to create an appointment form you will see some Javascript errors related to address completion and address completion does not work. If you load bootstrap filestyle and JQuery ui as shown in this pr, those javascript errors go away and address completion mostly works. (It doesn't seem to be styled correctly.) 