### PR TITLE
LUT-27497: Ensure that the values of certain Entries don't get overwritten when updating an appointment

### DIFF
--- a/src/java/fr/paris/lutece/plugins/appointment/service/AppointmentResponseService.java
+++ b/src/java/fr/paris/lutece/plugins/appointment/service/AppointmentResponseService.java
@@ -49,6 +49,7 @@ import fr.paris.lutece.plugins.appointment.business.appointment.AppointmentRespo
 import fr.paris.lutece.plugins.appointment.service.upload.AppointmentAsynchronousUploadHandler;
 import fr.paris.lutece.plugins.genericattributes.business.Entry;
 import fr.paris.lutece.plugins.genericattributes.business.EntryHome;
+import fr.paris.lutece.plugins.genericattributes.business.Field;
 import fr.paris.lutece.plugins.genericattributes.business.FieldHome;
 import fr.paris.lutece.plugins.genericattributes.business.GenAttFileItem;
 import fr.paris.lutece.plugins.genericattributes.business.Response;
@@ -204,6 +205,34 @@ public final class AppointmentResponseService
             Entry entry = EntryHome.findByPrimaryKey( response.getEntry( ).getIdEntry( ) );
             if ( !entry.isOnlyDisplayInBack( ) || deleteBoOnly )
             {
+                AppointmentResponseService.removeResponseById( response.getIdResponse( ) );
+            }
+        }
+    }
+
+    /**
+     * Remove the updatable Responses of an appointment
+     * 
+     * @param nIdAppointment
+     *            The id of the appointment
+     * @param deleteBoOnly
+     *            Set if the action is Back Office only
+     */
+    public static void removeUpdatableResponsesOnly( int nIdAppointment, boolean deleteBoOnly )
+    {
+        List<Response> listResponse = AppointmentResponseService.findListResponse( nIdAppointment );
+        for ( Response response : listResponse )
+        {
+            Entry entry = EntryHome.findByPrimaryKey( response.getEntry( ).getIdEntry( ) );
+            if ( !entry.isOnlyDisplayInBack( ) || deleteBoOnly )
+            {
+                Field updatableField = entry.getFieldByCode( IEntryTypeService.FIELD_IS_UPDATABLE );
+                // In case the Response is not updatable, make sure it doesn't get removed
+                if ( updatableField != null && !Boolean.valueOf( updatableField.getValue( ) ) )
+                {
+                    // Do nothing with this Response and process the next one
+                    continue;
+                }
                 AppointmentResponseService.removeResponseById( response.getIdResponse( ) );
             }
         }

--- a/src/sql/plugins/genericattributes/plugin/init_db_genericattributes_appointment.sql
+++ b/src/sql/plugins/genericattributes/plugin/init_db_genericattributes_appointment.sql
@@ -30,3 +30,10 @@ INSERT INTO genatt_entry_type (title,is_group,is_comment,is_mylutece_user,class_
 ('Fichier',0,0,0,'appointment.entryTypeFile','file','appointment',15,0);
 INSERT INTO genatt_entry_type (title,is_group,is_comment,is_mylutece_user,class_name,icon_name,plugin,display_order,inactive) VALUES 
 ('Numéro de téléphone',0,0,0,'appointment.entryTypePhone','phone-square','appointment',16,1);
+
+INSERT INTO genatt_field ( id_entry, title, code, value, default_value )
+	SELECT e.id_entry, e.title, 'is_updatable', 'false', 0
+	FROM genatt_entry e
+	INNER JOIN genatt_entry_type t ON t.id_type = e.id_type
+	WHERE e.resource_type = 'APPOINTMENT_FORM'
+	AND t.class_name = 'appointment.entryTypeSession';

--- a/src/sql/plugins/genericattributes/plugin/upgrade/update_db_generic_attributes_appointment_2.4.3-2.4.5.sql
+++ b/src/sql/plugins/genericattributes/plugin/upgrade/update_db_generic_attributes_appointment_2.4.3-2.4.5.sql
@@ -1,0 +1,9 @@
+/* Add a parameter to specify that Entries of type 'Session' should
+ * not be updated when an appointment is being modified
+ * */
+INSERT INTO genatt_field ( id_entry, title, code, value, default_value )
+	SELECT e.id_entry, e.title, 'is_updatable', 'false', 0
+	FROM genatt_entry e
+	INNER JOIN genatt_entry_type t ON t.id_type = e.id_type
+	WHERE e.resource_type = 'APPOINTMENT_FORM'
+	AND t.class_name = 'appointment.entryTypeSession';


### PR DESCRIPTION
The following PR for the plugin `lutece-genattrs-plugin-genericattributes` has to be merged first:
- https://github.com/lutece-platform/lutece-genattrs-plugin-genericattributes/pull/64

##### Description:
This is useful for Entries like "Session", when they don't have any field to enter a value during the modification / update process (the old value, if any existed, would be lost and no new value would replace it).