### PR TITLE
LUT-27860: Update the way a Text area Entry's content is displayed when viewing an appointment

### DIFF
--- a/webapp/WEB-INF/templates/admin/plugins/appointment/appointment/view_appointment.html
+++ b/webapp/WEB-INF/templates/admin/plugins/appointment/appointment/view_appointment.html
@@ -1,4 +1,3 @@
-<link rel="stylesheet" href="css/admin/plugins/appointment/appointment.css" >
 <@row class='calendar-row'>
 	<@columns>
 		<@box>
@@ -30,11 +29,7 @@
 							<#if hasFile>
 								<a href="jsp/admin/plugins/appointment/DoDownloadAppointmentsFile.jsp?idResponse=${response.idResponse}">
 							</#if>
-							<#if response.entry.entryType.beanName?ends_with('entryTypeTextArea')>
-								<pre class="viewTextarea">${response.recapValue}</pre>
-							<#else>
-								<@staticText>${response.recapValue} </@staticText>
-							</#if>
+							<@staticText>${response.recapValue} </@staticText>
 							<#if hasFile>
 								</a>
 							</#if>


### PR DESCRIPTION
When displaying a response from an Entry of type TextArea:
- The CSS used for `<pre>` elements would display the text in a light color, making it invisible on white backgrounds
- The default `<@staticText>` can be used to match the way the other Entry types are displayed