### PR TITLE
LUT-32712 : Fix cancel_appointment.html @cInput text fields missing required name parameter

### DIFF
--- a/webapp/WEB-INF/templates/skin/plugins/appointment/cancel_appointment.html
+++ b/webapp/WEB-INF/templates/skin/plugins/appointment/cancel_appointment.html
@@ -42,10 +42,10 @@
 				<@cInput type='hidden' name='action' value='doCancelAppointment' class='' />
 				<@cInput type='hidden' name='token' value='${token}' class='' />
 				<@cField label='#i18n{appointment.dateAppointment.title}'>
-					<@cInput type='text' disabled=true readonly=true value='${dateAppointment}' />
+					<@cInput type='text' name='dateAppointment' disabled=true readonly=true value='${dateAppointment}' />
 				</@cField>
 				<@cField label='#i18n{appointment.cancelAppointment.labelTimeAppointment}'>
-					<@cInput type='text' disabled=true readonly=true value='#i18n{appointment.labelFrom} ${startingTimeAppointment} #i18n{appointment.labelTo} ${endingTimeAppointment}' />
+					<@cInput type='text' name='timeAppointment' disabled=true readonly=true value='#i18n{appointment.labelFrom} ${startingTimeAppointment} #i18n{appointment.labelTo} ${endingTimeAppointment}' />
 				</@cField>
 				<!-- <@cRow class='mt-3'>
 					<@cCol>


### PR DESCRIPTION
Fixes Redmine [#32712](https://dev.lutece.paris.fr/bugtracker/issues/32712).

The two display-only `@cInput type='text'` fields (date/time) on the FO appointment cancellation page were called without the macro's required `name` parameter, raising a FreeMarker `_MiscTemplateException` (HTTP 500). Adds a `name` to both.