### PR TITLE
LUT-32930 : Fix appointment deletion

### DIFF
--- a/src/java/fr/paris/lutece/plugins/appointment/business/appointment/AppointmentDAO.java
+++ b/src/java/fr/paris/lutece/plugins/appointment/business/appointment/AppointmentDAO.java
@@ -121,10 +121,10 @@ public final class AppointmentDAO implements IAppointmentDAO
     private static final String SQL_SORT_USER_FIRST_NAME = "MAX(user.first_name)";
     private static final String SQL_SORT_USER_EMAIL = "MAX(user.email)";
     private static final String SQL_SORT_USER_PHONE_NUMBER = "MAX(user.phone_number)";
-    private static final String SQL_SORT_APP_NB_PLACES = "MAX(app.nb_places)";
+    private static final String SQL_SORT_APP_NB_PLACES = "app.nb_places";
     private static final String SQL_SORT_SLOT_STARTING_DATE_TIME = "MIN(slot.starting_date_time)";
-    private static final String SQL_SORT_APP_ID_ADMIN_USER = "MAX(app.id_admin_user)";
-    private static final String SQL_SORT_APP_IS_CANCELLED = "MAX(app.is_cancelled)";
+    private static final String SQL_SORT_APP_ID_ADMIN_USER = "app.id_admin_user";
+    private static final String SQL_SORT_APP_IS_CANCELLED = "app.is_cancelled";
     private static final String SQL_SORT_ASC = " ASC ";
     private static final String SQL_SORT_DESC = " DESC ";
 

--- a/src/java/fr/paris/lutece/plugins/appointment/business/appointment/AppointmentDAO.java
+++ b/src/java/fr/paris/lutece/plugins/appointment/business/appointment/AppointmentDAO.java
@@ -84,7 +84,7 @@ public final class AppointmentDAO implements IAppointmentDAO
             + " INNER JOIN appointment_appointment_slot app_slot ON app.id_appointment = app_slot.id_appointment"
             + " INNER JOIN appointment_slot slot ON app_slot.id_slot = slot.id_slot WHERE id_form != 0";
     private static final String SQL_QUERY_SELECT_IDS_BY_FILTER = "SELECT "
-            + " DISTINCT app.id_appointment"
+            + " app.id_appointment"
             + " FROM appointment_appointment app " + "INNER JOIN appointment_user user ON app.id_user = user.id_user "
             + " INNER JOIN appointment_appointment_slot app_slot ON app.id_appointment = app_slot.id_appointment"
             + " INNER JOIN appointment_slot slot ON app_slot.id_slot = slot.id_slot WHERE id_form != 0";
@@ -117,14 +117,14 @@ public final class AppointmentDAO implements IAppointmentDAO
     private static final String SQL_FILTER_ID_LIST_START = "app.id_appointment IN ( ";
     private static final String SQL_FILTER_ID_LIST_END = " ) ";
 
-    private static final String SQL_SORT_USER_LAST_NAME = "user.last_name";
-    private static final String SQL_SORT_USER_FIRST_NAME = "user.first_name";
-    private static final String SQL_SORT_USER_EMAIL = "user.email";
-    private static final String SQL_SORT_USER_PHONE_NUMBER = "user.phone_number";
-    private static final String SQL_SORT_APP_NB_PLACES = "app.nb_places";
-    private static final String SQL_SORT_SLOT_STARTING_DATE_TIME = "slot.starting_date_time";
-    private static final String SQL_SORT_APP_ID_ADMIN_USER = "app.id_admin_user";
-    private static final String SQL_SORT_APP_IS_CANCELLED = "app.is_cancelled";
+    private static final String SQL_SORT_USER_LAST_NAME = "MAX(user.last_name)";
+    private static final String SQL_SORT_USER_FIRST_NAME = "MAX(user.first_name)";
+    private static final String SQL_SORT_USER_EMAIL = "MAX(user.email)";
+    private static final String SQL_SORT_USER_PHONE_NUMBER = "MAX(user.phone_number)";
+    private static final String SQL_SORT_APP_NB_PLACES = "MAX(app.nb_places)";
+    private static final String SQL_SORT_SLOT_STARTING_DATE_TIME = "MIN(slot.starting_date_time)";
+    private static final String SQL_SORT_APP_ID_ADMIN_USER = "MAX(app.id_admin_user)";
+    private static final String SQL_SORT_APP_IS_CANCELLED = "MAX(app.is_cancelled)";
     private static final String SQL_SORT_ASC = " ASC ";
     private static final String SQL_SORT_DESC = " DESC ";
 
@@ -421,6 +421,7 @@ public final class AppointmentDAO implements IAppointmentDAO
         List<Integer> list = new ArrayList<>( );
 
         String sqlQueryFromFilter = getSqlQueryFromFilter(appointmentFilter, SQL_QUERY_SELECT_IDS_BY_FILTER);
+        sqlQueryFromFilter += " GROUP BY app.id_appointment";
         String sqlQuery = getOrderQuery( appointmentFilter, sqlQueryFromFilter );
         try (DAOUtil daoUtil = new DAOUtil(sqlQuery, plugin ) )
         {

--- a/src/java/fr/paris/lutece/plugins/appointment/business/appointment/AppointmentResponseHome.java
+++ b/src/java/fr/paris/lutece/plugins/appointment/business/appointment/AppointmentResponseHome.java
@@ -106,8 +106,8 @@ public final class AppointmentResponseHome
             Response response = ResponseHome.findByPrimaryKey( nIdResponse );
             if ( response == null )
             {
-                AppLogService.error( "Orphan appointment response: Table appointment_response references a missing genatt_response. id_appointment="
-                        + nIdAppointment + ", id_response=" + nIdResponse );
+                AppLogService.error( "Orphan appointment response: Table appointment_response references a missing genatt_response. id_appointment={}, id_response={}",
+                        nIdAppointment, nIdResponse );
                 continue;
             }
             if ( response.getField( ) != null && response.getField( ).getIdField( ) != 0 )

--- a/src/java/fr/paris/lutece/plugins/appointment/business/appointment/AppointmentResponseHome.java
+++ b/src/java/fr/paris/lutece/plugins/appointment/business/appointment/AppointmentResponseHome.java
@@ -43,6 +43,7 @@ import fr.paris.lutece.plugins.genericattributes.business.ResponseHome;
 import fr.paris.lutece.portal.service.plugin.Plugin;
 import fr.paris.lutece.portal.service.plugin.PluginService;
 import fr.paris.lutece.portal.service.spring.SpringContextService;
+import fr.paris.lutece.portal.service.util.AppLogService;
 
 /**
  * Appointment Response Home
@@ -103,6 +104,12 @@ public final class AppointmentResponseHome
         for ( Integer nIdResponse : listIdResponse )
         {
             Response response = ResponseHome.findByPrimaryKey( nIdResponse );
+            if ( response == null )
+            {
+                AppLogService.error( "Orphan appointment response: Table appointment_response references a missing genatt_response. id_appointment="
+                        + nIdAppointment + ", id_response=" + nIdResponse );
+                continue;
+            }
             if ( response.getField( ) != null && response.getField( ).getIdField( ) != 0 )
             {
                 response.setField( FieldHome.findByPrimaryKey( response.getField( ).getIdField( ) ) );

--- a/src/java/fr/paris/lutece/plugins/appointment/service/AppointmentResponseService.java
+++ b/src/java/fr/paris/lutece/plugins/appointment/service/AppointmentResponseService.java
@@ -142,8 +142,8 @@ public final class AppointmentResponseService
             Response response = ResponseHome.findByPrimaryKey( nIdResponse );
             if ( response == null )
             {
-                AppLogService.error( "Orphan appointment response : Table appointment_response references a missing genatt_response. id_appointment="
-                        + nIdAppointment + ", id_response=" + nIdResponse );
+                AppLogService.error( "Orphan appointment response: Table appointment_response references a missing genatt_response. id_appointment={}, id_response={}",
+                        nIdAppointment, nIdResponse );
                 continue;
             }
             if ( response.getField( ) != null )

--- a/src/java/fr/paris/lutece/plugins/appointment/service/AppointmentResponseService.java
+++ b/src/java/fr/paris/lutece/plugins/appointment/service/AppointmentResponseService.java
@@ -140,6 +140,12 @@ public final class AppointmentResponseService
         for ( int nIdResponse : listIdResponse )
         {
             Response response = ResponseHome.findByPrimaryKey( nIdResponse );
+            if ( response == null )
+            {
+                AppLogService.error( "Orphan appointment response : Table appointment_response references a missing genatt_response. id_appointment="
+                        + nIdAppointment + ", id_response=" + nIdResponse );
+                continue;
+            }
             if ( response.getField( ) != null )
             {
                 response.setField( FieldHome.findByPrimaryKey( response.getField( ).getIdField( ) ) );
@@ -192,10 +198,10 @@ public final class AppointmentResponseService
      */
     public static void removeResponsesByIdAppointment( int nIdAppointment )
     {
-        List<Response> listResponse = AppointmentResponseService.findListResponse( nIdAppointment );
-        for ( Response response : listResponse )
+        List<Integer> listIdResponse = AppointmentResponseService.findListIdResponse( nIdAppointment );
+        for ( Integer nIdResponse : listIdResponse )
         {
-            AppointmentResponseService.removeResponseById( response.getIdResponse( ) );
+            AppointmentResponseService.removeResponseById( nIdResponse );
         }
     }
 

--- a/src/java/fr/paris/lutece/plugins/appointment/service/AppointmentService.java
+++ b/src/java/fr/paris/lutece/plugins/appointment/service/AppointmentService.java
@@ -352,6 +352,7 @@ public final class AppointmentService
         }
         appointmentDTO.setSlot( appointment.getSlot( ) );
         appointmentDTO.setUser( appointment.getUser( ) );
+        appointmentDTO.setAdminUser( StringUtils.EMPTY );
         if ( appointment.getIdAdminUser( ) != 0 )
         {
             AdminUser adminUser = AdminUserHome.findByPrimaryKey( appointment.getIdAdminUser( ) );
@@ -361,10 +362,6 @@ public final class AppointmentService
                 appointmentDTO.setAdminUser(
                         new StringBuilder( adminUser.getFirstName( ) + org.apache.commons.lang3.StringUtils.SPACE + adminUser.getLastName( ) ).toString( ) );
             }
-        }
-        else
-        {
-            appointmentDTO.setAdminUser( StringUtils.EMPTY );
         }
         appointmentDTO.setAdminUserCreate( appointment.getAdminUserCreate( ) );
         appointmentDTO.setDateAppointmentTaken( appointment.getDateAppointmentTaken( ) );
@@ -413,7 +410,11 @@ public final class AppointmentService
             // Need to delete also the responses linked to this appointment
             AppointmentResponseService.removeResponsesByIdAppointment( nIdAppointment );
             AppointmentService.deleteAppointment( appointmentToDelete );
-            UserHome.delete( appointmentToDelete.getIdUser( ) );
+            //Delete id_user in table appointment_user if zero reference found in appointment_appointment
+            if ( CollectionUtils.isEmpty( findListAppointmentByUserId( appointmentToDelete.getIdUser( ) ) ) )
+            {
+                UserHome.delete( appointmentToDelete.getIdUser( ) );
+            }
             TransactionManager.commitTransaction( AppointmentPlugin.getPlugin( ) );
             AppointmentListenerManager.notifyListenersAppointmentRemoval( nIdAppointment );
             for ( AppointmentSlot appSlot : appointmentToDelete.getListAppointmentSlot( ) )

--- a/src/java/fr/paris/lutece/plugins/appointment/service/AppointmentService.java
+++ b/src/java/fr/paris/lutece/plugins/appointment/service/AppointmentService.java
@@ -410,11 +410,7 @@ public final class AppointmentService
             // Need to delete also the responses linked to this appointment
             AppointmentResponseService.removeResponsesByIdAppointment( nIdAppointment );
             AppointmentService.deleteAppointment( appointmentToDelete );
-            //Delete id_user in table appointment_user if zero reference found in appointment_appointment
-            if ( CollectionUtils.isEmpty( findListAppointmentByUserId( appointmentToDelete.getIdUser( ) ) ) )
-            {
-                UserHome.delete( appointmentToDelete.getIdUser( ) );
-            }
+            UserHome.delete( appointmentToDelete.getIdUser( ) );
             TransactionManager.commitTransaction( AppointmentPlugin.getPlugin( ) );
             AppointmentListenerManager.notifyListenersAppointmentRemoval( nIdAppointment );
             for ( AppointmentSlot appSlot : appointmentToDelete.getListAppointmentSlot( ) )

--- a/src/sql/plugins/appointment/upgrade/update_db_appointment_3.0.8-3.0.13.sql
+++ b/src/sql/plugins/appointment/upgrade/update_db_appointment_3.0.8-3.0.13.sql
@@ -1,0 +1,84 @@
+-- liquibase formatted sql
+-- changeset appointment:update_db_appointment_3.0.8-3.0.13.sql
+-- preconditions onFail:MARK_RAN onError:WARN
+
+-- Repair duplicate user on appointment : Create unique id_user for each duplicate user
+DELIMITER //
+CREATE PROCEDURE repair_appointment_users()
+BEGIN
+    DECLARE done INT DEFAULT FALSE;
+    DECLARE v_appointment_id INT;
+    DECLARE v_old_user_id INT;
+    DECLARE v_new_user_id INT;
+
+    -- Get all duplicate user
+    DECLARE cur CURSOR FOR 
+        SELECT id_appointment, id_user 
+        FROM appointment_appointment 
+        WHERE id_appointment NOT IN (
+            SELECT max_id FROM (SELECT MAX(id_appointment) as max_id FROM appointment_appointment GROUP BY id_user) as tmp
+        );
+    DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE;
+
+    OPEN cur;
+    read_loop: LOOP
+        FETCH cur INTO v_appointment_id, v_old_user_id;
+        IF done THEN
+            LEAVE read_loop;
+        END IF;
+
+        -- Create new user (to replace duplicate user)
+        INSERT INTO appointment_user (guid, first_name, last_name, email, phone_number)
+        SELECT guid, first_name, last_name, email, phone_number 
+        FROM appointment_user 
+        WHERE id_user = v_old_user_id;
+        
+        SET v_new_user_id = LAST_INSERT_ID();
+
+        -- Update appointment with the new user
+        UPDATE appointment_appointment 
+        SET id_user = v_new_user_id 
+        WHERE id_appointment = v_appointment_id;
+    END LOOP;
+    CLOSE cur;
+END //
+DELIMITER ;
+
+CALL repair_appointment_users();
+DROP PROCEDURE repair_appointment_users;
+
+-- Delete appointments already moved to the target state of a DELETE archive task.
+DELETE appointment_response, response
+FROM appointment_appointment_response appointment_response
+INNER JOIN genatt_response response ON response.id_response = appointment_response.id_response
+INNER JOIN appointment_appointment app ON app.id_appointment = appointment_response.id_appointment
+INNER JOIN workflow_resource_workflow rw
+    ON rw.id_resource = app.id_appointment
+    AND rw.resource_type = 'appointment'
+INNER JOIN workflow_task_archive_cf archive_cf ON archive_cf.next_state = rw.id_state
+INNER JOIN workflow_task archive_task ON archive_task.id_task = archive_cf.id_task
+INNER JOIN workflow_action archive_action ON archive_action.id_action = archive_task.id_action AND archive_action.id_workflow = rw.id_workflow
+WHERE archive_cf.type_archival = 'DELETE';
+
+-- Delete appointment slots already moved to the target state of a DELETE archive task.
+DELETE appointment_slot
+FROM appointment_appointment_slot appointment_slot
+INNER JOIN appointment_appointment app ON app.id_appointment = appointment_slot.id_appointment
+INNER JOIN workflow_resource_workflow rw
+    ON rw.id_resource = app.id_appointment
+    AND rw.resource_type = 'appointment'
+INNER JOIN workflow_task_archive_cf archive_cf ON archive_cf.next_state = rw.id_state
+INNER JOIN workflow_task archive_task ON archive_task.id_task = archive_cf.id_task
+INNER JOIN workflow_action archive_action ON archive_action.id_action = archive_task.id_action AND archive_action.id_workflow = rw.id_workflow
+WHERE archive_cf.type_archival = 'DELETE';
+
+-- Delete appointment already moved to the target state of a DELETE archive task.
+DELETE app
+FROM appointment_appointment app
+INNER JOIN workflow_resource_workflow rw ON rw.id_resource = app.id_appointment AND rw.resource_type = 'appointment'
+INNER JOIN workflow_task_archive_cf archive_cf ON archive_cf.next_state = rw.id_state
+INNER JOIN workflow_task archive_task ON archive_task.id_task = archive_cf.id_task
+INNER JOIN workflow_action archive_action ON archive_action.id_action = archive_task.id_action AND archive_action.id_workflow = rw.id_workflow
+WHERE archive_cf.type_archival = 'DELETE';
+
+


### PR DESCRIPTION
**ISSUE #1**  : Error during deleting appointment

<img width="2129" height="2004" alt="image" src="https://github.com/user-attachments/assets/eaf83108-cf1c-4800-acc9-05fb07f12b84" />

The issue is when we try to delete an appointment after changing it status to _Archived - Deleted_  , an error is raised, because a foreign key exist between **appointment_appointment.id_user** and **appointment_user.id_user**. Previously, we tried to delete the user ID from the user table when deleting an appointment. However, **a user MAY have multiple appointments at the same time**, so the foreign key constraint prevents this deletion.

With the fix, we now check if there are any remaining appointments for that user before attempting to delete. If there are any remaining, we do not delete the user ID.

<img width="1936" height="196" alt="image" src="https://github.com/user-attachments/assets/dfecde5b-538d-4ffa-8d6e-df35c35d9e7b" />

We also fixed the SQL_QUERY_SELECT_IDS_BY_FILTER query, which was performing a GROUP BY on columns that were not referenced—something that is prohibited by SQL standards. [Documentation](https://dev.mysql.com/doc/refman/9.7/en/group-by-handling.html)

**ISSUE #2**  :  Null value during indexing

<img width="3256" height="336" alt="image" src="https://github.com/user-attachments/assets/ed7c18b7-ff8b-4b1b-9fa6-3b9b6cc484c9" />

The problem here is that if an admin user disappears but the appointment still considers that it has one **(appointment.getIdAdminUser() != 0)**, then adminUser will be null, and we will never enter the loop that sets the user to EMPTY. 

<img width="1808" height="358" alt="image" src="https://github.com/user-attachments/assets/ceae3bbb-20f5-42ac-ab87-8f0079648862" /> 

The simple solution here is to start by setting AdminUser to empty (in the else condition)

<img width="1819" height="531" alt="image" src="https://github.com/user-attachments/assets/429fcd93-baf9-4eb0-9710-f037f38cdc1c" />

If it exists, it will be replaced; otherwise, it will remain empty and will not cause any problems.

**ISSUE #3** : Viewing an appointment results in an error. 

<img width="1244" height="296" alt="image" src="https://github.com/user-attachments/assets/04e3d311-8449-45cc-b8c6-c545136f086e" />

It appears there are missing links between the **genatt_response.id_response** and **appointment_appointment_response.id_response** tables. The **genatt_response** table contains the responses for an appointment, so if data is deleted, the responses cannot be found, which causes an error. Locally, I haven’t found any obvious cause for this problem in the code; it could be due to an issue with the database or the session. That’s why I’ve added error logs so we’ll know where the problem is coming from in the future. 

<img width="1931" height="891" alt="image" src="https://github.com/user-attachments/assets/06778e89-abc4-48a8-80fa-e85139bd44b0" />
